### PR TITLE
Build changes for win32

### DIFF
--- a/src/Make_MinGW.bat
+++ b/src/Make_MinGW.bat
@@ -3,15 +3,18 @@ REM   and will use the MinGW C-compiler.
 REM  It will compile all the tax-form programs.  But it will only build the 
 REM   old Otk-based GUI; not the newer Gtk-based GUI.
 
-gcc -O taxsolve_US_1040_2014.c -o ..\msbin\taxsolve_US_1040_2014
-gcc -O taxsolve_US_1040_Sched_C_2014.c -o ..\msbin\taxsolve_US_1040_Sched_C_2014
+mkdir ..\msbin
 
-gcc -O taxsolve_CA_540_2014.c   -o ..\msbin\taxsolve_CA_540_2014
-gcc -O taxsolve_NC_D400_2014.c  -o ..\msbin\taxsolve_NC_D400_2014
-gcc -O taxsolve_NJ_1040_2014.c  -o ..\msbin\taxsolve_NJ_1040_2014
-gcc -O taxsolve_PA_40_2014.c    -o ..\msbin\taxsolve_PA_40_2014
-gcc -O taxsolve_OH_IT1040_2014.c -o ..\msbin\taxsolve_OH_IT1040_2014
-gcc -O taxsolve_VA_760_2014.c   -o ..\msbin\taxsolve_VA_760_2014
-gcc -O taxsolve_NY_IT201_2014.c -o ..\msbin\taxsolve_NY_IT201_2014
-gcc -O taxsolve_MA_1_2014.c     -o ..\msbin\taxsolve_MA_1_2014
-gcc -O Run_taxsolve_GUI.c 	  -o ..\Run_taxsolve_GUI_mswin
+REM tested with gcc version 4.8.3
+g++ -O -std=c++11 taxsolve_US_1040_2014.c -o ..\msbin\taxsolve_US_1040_2014
+g++ -O -std=c++11 taxsolve_US_1040_Sched_C_2014.c -o ..\msbin\taxsolve_US_1040_Sched_C_2014
+
+g++ -O -std=c++11 taxsolve_CA_540_2014.c   -o ..\msbin\taxsolve_CA_540_2014
+g++ -O -std=c++11 taxsolve_NC_D400_2014.c  -o ..\msbin\taxsolve_NC_D400_2014
+g++ -O -std=c++11 taxsolve_NJ_1040_2014.c  -o ..\msbin\taxsolve_NJ_1040_2014
+g++ -O -std=c++11 taxsolve_PA_40_2014.c    -o ..\msbin\taxsolve_PA_40_2014
+g++ -O -std=c++11 taxsolve_OH_IT1040_2014.c -o ..\msbin\taxsolve_OH_IT1040_2014
+g++ -O -std=c++11 taxsolve_VA_760_2014.c   -o ..\msbin\taxsolve_VA_760_2014
+g++ -O -std=c++11 taxsolve_NY_IT201_2014.c -o ..\msbin\taxsolve_NY_IT201_2014
+g++ -O -std=c++11 taxsolve_MA_1_2014.c     -o ..\msbin\taxsolve_MA_1_2014
+g++ -O -std=c++11 Run_taxsolve_GUI.c 	  -o ..\Run_taxsolve_GUI_mswin


### PR DESCRIPTION
Tested with gcc 4.8.3 (as supplied by Strawberry Perl).
NOTE build warnings:

taxsolve_US_1040_2014.c: In function 'int main(int, char**)':
taxsolve_US_1040_2014.c:1132:23: warning: deprecated conversion from string constant to 'char_' [-Wwrite-strings]
  get_cap_gains( "L13" );  /_ Capital gains. (Schedule-D) _/
                       ^
taxsolve_US_1040_2014.c:1306:51: warning: deprecated conversion from string constant to 'char_' [-Wwrite-strings]
   showschedA_wMsg(18, "Carryover from prior year" );
                                                   ^
taxsolve_US_1040_2014.c:1511:53: warning: deprecated conversion from string constant to 'char*' [-Wwrite-strings]
  ShowLineNonZero_wMsg(45, "Alternative Minimum Tax" );
                                                     ^
taxsolve_NC_D400_2014.c: In function 'int main(int, char**)':
taxsolve_NC_D400_2014.c:350:65: warning: deprecated conversion from string constant to 'char_' [-Wwrite-strings]
  showline_wlabelmsg( "L20", L[20], "North Carolina Tax Withheld");
                                                                 ^
taxsolve_NC_D400_2014.c:350:65: warning: deprecated conversion from string constant to 'char_' [-Wwrite-strings]
